### PR TITLE
refactor: Use FormRequest for post creation validation

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,7 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
-use Illuminate\Http\Request;
+// Removed Illuminate\Http\Request as it's no longer used.
+use App\Http\Requests\StorePostRequest;
 
 class PostController extends Controller
 {
@@ -27,14 +28,12 @@ class PostController extends Controller
     }
 
     // Store a new post
-    public function store(Request $request)
+    public function store(StorePostRequest $request) // Changed type-hint to StorePostRequest
     {
-        $request->validate([
-            'title' => 'required|max:255',
-            'body' => 'required',
-        ]);
+        // Validation is now handled by StorePostRequest before this method is called.
+        // The $request->validate(...) call is no longer needed here.
 
-        Post::create($request->all());
+        Post::create($request->validated()); // Use validated data from the form request
         return redirect()->route('posts.index');
     }
 }

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        // For now, let's assume anyone can create a post.
+        // This can be changed later based on authentication/authorization logic.
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|max:255',
+            'body' => 'required',
+        ];
+    }
+}


### PR DESCRIPTION
- Created StorePostRequest to handle validation for creating posts.
- Moved validation rules from PostController@store to StorePostRequest.
- Updated PostController@store to use StorePostRequest for validation and data retrieval.

This change centralizes validation logic, making the controller cleaner and adhering to Laravel best practices.